### PR TITLE
Add the ability to remove yaml front matter from documents

### DIFF
--- a/lib/gimli/markup.rb
+++ b/lib/gimli/markup.rb
@@ -42,7 +42,8 @@ module Gimli
     #
     # @return [String] The formatted data
     def render
-      data = extract_code(@data.dup)
+      data = remove_yaml_front_matter(@data.dup)
+      data = extract_code(data)
       data = extract_tags(data)
       begin
         data = data.force_encoding('utf-8') if data.respond_to? :force_encoding
@@ -66,6 +67,19 @@ module Gimli
 
     def doc_to_html(doc)
       doc.to_xhtml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XHTML, :encoding => 'UTF-8')
+    end
+
+    # Removes YAML Front Matter if the removefrontmatter flag is true. 
+    # Useful if you want to PDF your Jekyll site.
+    #
+    # @param [String] data - The raw string data.
+    # @return [String] Returns the string data with frontmatter removed
+    def remove_yaml_front_matter(data)
+      if ARGV.flags.removefrontmatter? 
+        data.gsub(/^(---\s*\n.*?\n?)^(---\s*$\n?)/m, '')
+      else
+        data
+      end
     end
 
     # Extract all tags into the tagmap and replace with placeholders.

--- a/lib/gimli/setup.rb
+++ b/lib/gimli/setup.rb
@@ -28,6 +28,10 @@ module Gimli extend OptiFlagSet
     description 'Merge markup files into single pdf file'
     alternate_forms 'm'
   end
+  optional_switch_flag 'removefrontmatter' do
+    description 'Remove yaml frontmatter from your files.'
+    alternate_forms 'y'
+  end
   optional_switch_flag 'version' do
     description 'Show version information and quit'
     alternate_forms 'v'

--- a/spec/fixtures/yaml_front_matter.textile
+++ b/spec/fixtures/yaml_front_matter.textile
@@ -1,0 +1,7 @@
+---
+layout: test
+---
+
+
+
+This should be at the top of the file

--- a/spec/gimli/markup_spec.rb
+++ b/spec/gimli/markup_spec.rb
@@ -57,6 +57,17 @@ describe Gimli::Markup do
 
     markup.render.should == output
   end
+  
+  it "should remove yaml front matter if asked to" do
+    output = "<p>This should be at the top of the file</p>"
+    
+    mock(ARGV).flags.mock!.removefrontmatter? { true }
+    
+    file = Gimli::MarkupFile.new File.expand_path('../../fixtures/yaml_front_matter.textile', __FILE__)
+    markup = Gimli::Markup.new file
+
+    markup.render.should == output
+  end
 
 end
 


### PR DESCRIPTION
Hi Mate,

Can across your project tonight while I was playing with [mojombo/jekyll](https://github.com/mojombo/jekyll). I wanted to PDF parts of the site (i.e. blog posts, resume) so that they could be downloaded. 

Problem was the Jekyll requires [YAML Front Matter](https://github.com/mojombo/jekyll/wiki/YAML-Front-Matter) for its layout processing and it was junking up my PDFs.

This commit adds a flag `-y` that will remove the yaml from the top of the document before it is converted.

Keep up the awesome work.

Cheers,
Chris
