### PR TITLE
Properly handle smart quotes from Textile.

### DIFF
--- a/lib/gimli/markup.rb
+++ b/lib/gimli/markup.rb
@@ -59,7 +59,7 @@ module Gimli
       data = process_tags(data)
       data = process_code(data)
 
-      doc  = Nokogiri::HTML::DocumentFragment.parse(data, 'UTF-8')
+      doc  = Nokogiri.HTML(data.encode('ASCII-8BIT'))
       yield doc if block_given?
       data = doc_to_html(doc)
 
@@ -68,7 +68,7 @@ module Gimli
     end
 
     def doc_to_html(doc)
-      doc.to_xhtml(:save_with => Nokogiri::XML::Node::SaveOptions::AS_XHTML, :encoding => 'UTF-8')
+      doc.css('body').inner_html()
     end
 
     # Removes YAML Front Matter

--- a/spec/gimli/markup_spec.rb
+++ b/spec/gimli/markup_spec.rb
@@ -15,5 +15,13 @@ describe Gimli::Markup do
     markup.render.should == output
   end
 
+  it "should handle textile-converted quotes properly" do
+    output = %q(<p>&ldquo;Double&rdquo; and &lsquo;single&rsquo; quotes are handled properly.</p>)
+
+    file = Gimli::MarkupFile.new File.expand_path('../../fixtures/quotes.textile', __FILE__)
+    markup = Gimli::Markup.new file, true
+
+    markup.render.should == output
+  end
 end
 


### PR DESCRIPTION
Hello.

I had problems getting the Textile-generated smart quotes through to pdf. The reason turned out to be the usage of utf-8 encoding and Nokogiri XML document parser. I switched to ASCII-8BIT and HTML and got the desired functionality without breaking the tests.

Please see the explanation here: http://stackoverflow.com/questions/4476047/how-to-make-nokogiri-not-to-convert-nbsp-to-space

This is a big change so I understand that you may want to clean it up or test more or even reject the request. Please feel free to contact me if any more help needed though.

A (now working) testcase added.
