### PR TITLE
Fixed "can't convert Array into String" error on install

### DIFF
--- a/gimli.gemspec
+++ b/gimli.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob("{bin,ext,lib,spec,config}/**/*") + ['LICENSE', 'README.textile']
   s.executables = ['gimli']
-  s.require_path = ['lib']
+  s.require_paths = ['lib']
 end
 


### PR DESCRIPTION
This fixes the following error when installing gimli via gem when gems like
`gem-ctags` or `rdoc` are already installed:

```
ERROR:  While executing gem ... (TypeError)
   can't convert Array into String
```

This is because `require_path=` accepts a string, not an array. However,
`require_paths=` accepts an array.
