### PR TITLE
gitignore: .bundle and tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ pkg/
 doc/
 coverage/
 .yardoc/
+/.bundle/
+/tags
 Gemfile.lock
 .DS_Store


### PR DESCRIPTION
The `.bundle` directory is created if you pass arguments to
`bundle`.

The `tags` file is created when you use ctags, such as with
`gem-ctags`.
