### PR TITLE
Add --cover option for creating cover with markdown file

### DIFF
--- a/bin/gimli
+++ b/bin/gimli
@@ -19,6 +19,7 @@ config = Gimli.configure do |config|
   config.output_filename = ARGV.flags.outputfilename
   config.output_dir = ARGV.flags.outputdir
   config.stylesheet = ARGV.flags.stylesheet
+  config.cover = ARGV.flags.cover
 end
 
 Gimli.process! config

--- a/config/style.css
+++ b/config/style.css
@@ -172,3 +172,8 @@ table tr {
 table tr:nth-child(2n) {
   background-color: #f8f8f8;
 }
+
+.cover {
+  text-align: center;
+  margin-top: 100px;
+}

--- a/lib/gimli/config.rb
+++ b/lib/gimli/config.rb
@@ -4,7 +4,7 @@ module Gimli
 
   # Class that keeps the config parameters
   class Config
-    attr_accessor :file, :recursive, :merge, :debug, :wkhtmltopdf_parameters, :remove_front_matter, :output_filename, :output_dir, :stylesheet
+    attr_accessor :file, :recursive, :merge, :debug, :wkhtmltopdf_parameters, :remove_front_matter, :output_filename, :output_dir, :stylesheet, :cover
 
     # Sets default values
     def initialize

--- a/lib/gimli/converter.rb
+++ b/lib/gimli/converter.rb
@@ -9,6 +9,8 @@ module Gimli
   # The class that converts the files
   class Converter
 
+    COVER_FILE_PATH = ::File.expand_path("../../../config/cover.html", __FILE__)
+
     # Initialize the converter with a File
     # @param [Array] files The list of Gimli::MarkupFile to convert (passing a single file will still work)
     # @param [Gimli::Config] config
@@ -16,7 +18,9 @@ module Gimli
       @files, @config = files, config
 
       @stylesheets = []
-      @wkhtmltopdf = Wkhtmltopdf.new @config.wkhtmltopdf_parameters
+      parameters = [@config.wkhtmltopdf_parameters]
+      parameters << '--cover' << COVER_FILE_PATH if config.cover
+      @wkhtmltopdf = Wkhtmltopdf.new parameters.join(' ')
     end
 
     # Convert the file and save it as a PDF file
@@ -57,13 +61,14 @@ module Gimli
     # @param [String] filename the name of the output file
     def output_pdf(html, filename)
       load_stylesheets
+      generate_cover!
       append_stylesheets html
       add_head html
       @wkhtmltopdf.output_pdf html, output_file(filename)
     end
 
     def add_head(html)
-        html.insert(0, "\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n</head>\n")
+      html.insert(0, "\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n</head>\n")
     end
 
     # Load the stylesheets to pdfkit loads the default and the user selected if any
@@ -114,6 +119,19 @@ module Gimli
       end
 
       ::File.join(output_dir, "#{output_filename}.pdf")
+    end
+
+    # Generate cover file if optional cover was given
+    def generate_cover!
+      return unless @config.cover
+      cover_file = MarkupFile.new @config.cover
+      markup = Markup::Renderer.new cover_file
+      html = "<div class=\"cover\">\n#{markup.render}\n</div>"
+      append_stylesheets(html)
+      add_head(html)
+      File.open(COVER_FILE_PATH, 'w') do |f|
+        f.write html
+      end
     end
   end
 end

--- a/lib/gimli/setup.rb
+++ b/lib/gimli/setup.rb
@@ -44,6 +44,10 @@ module Gimli extend OptiFlagSet
     description 'Show version information and quit'
     alternate_forms 'v'
   end
+  optional_flag 'cover' do
+    description 'Create cover with the first headline'
+    alternate_forms 'c'
+  end
   usage_flag 'h', 'help', '?'
 
   and_process!

--- a/spec/gimli/converter_spec.rb
+++ b/spec/gimli/converter_spec.rb
@@ -120,5 +120,20 @@ describe Gimli::Converter do
 
     converter.convert_image_urls(html, filename).should == valid_html
   end
+
+  it 'should create a cover file if given cover option' do
+    file = Gimli::MarkupFile.new 'fake'
+    config = Gimli.configure do |config|
+      config.cover = 'fake'
+    end
+    converter = Gimli::Converter.new file, config
+    any_instance_of(Gimli::Markup::Renderer) do |renderer|
+      stub(renderer).render { 'fake' }
+    end
+
+    FileUtils.rm_f(Gimli::Converter::COVER_FILE_PATH)
+    converter.generate_cover!
+    File.exists?(Gimli::Converter::COVER_FILE_PATH).should == true
+  end
 end
 


### PR DESCRIPTION
## Create cover written by markdown

Because wkhtmltopdf has `--cover` option, you can create pdf with cover as follows.

```
gimli -f foo.md -w '--cover bar.html'
```

This pull request adds `--cover` option to gimli so that you can create cover written by markdown.
## Usage

```
gimli -f foo.md --cover bar.md
```

Then pdf will have a cover.
All texts in the cover will be center-aligned.
