### PR TITLE
Fix travis.ci errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ script: "rake"
 rvm:
   - 1.8.7
   - 1.9.2
+  - 2.0.0
+  - 2.1.0
   - ree
-
+gemfile: gemfiles/Gemfile.ci

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 group :test do

--- a/gemfiles/Gemfile.ci
+++ b/gemfiles/Gemfile.ci
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec :path => '..'


### PR DESCRIPTION
Your Travis.ci builds are failed:

```
Gem::InstallError: celluloid requires Ruby version >= 1.9.2.
An error occurred while installing celluloid (0.15.2), and Bundler cannot
```

Gems related to guard causes the error.
So, I add simple gemfile for ci.
