### PR TITLE
Remove "--quiet" option from wkhtmltopdf bin call

### DIFF
--- a/lib/gimli/wkhtmltopdf.rb
+++ b/lib/gimli/wkhtmltopdf.rb
@@ -27,7 +27,7 @@ module Gimli
     # @param [String] filename the outputed pdf's filename
     # @return [Array] a list of strings that make out the call to wkhtmltopdf
     def command(filename)
-      [bin, @parameters, '--quiet', '-', "\"#{filename}\""].compact
+      [bin, @parameters, '-', "\"#{filename}\""].compact
     end
 
     # Find the wkhtmltopdf binary


### PR DESCRIPTION
The "--quiet" option was causing the error "Unknown long argument
--quiet" on wkhtmltopdf version 0.8.3 installed in Mac OSX Mountain Lion
when trying to convert a markdown file.
