### PR TITLE
Create cover html by Tempfile

### DIFF
--- a/lib/gimli/converter.rb
+++ b/lib/gimli/converter.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'fileutils'
+require 'tempfile'
 
 require 'gimli/markup'
 
@@ -8,8 +9,6 @@ module Gimli
 
   # The class that converts the files
   class Converter
-
-    COVER_FILE_PATH = ::File.expand_path("../../../config/cover.html", __FILE__)
 
     # Initialize the converter with a File
     # @param [Array] files The list of Gimli::MarkupFile to convert (passing a single file will still work)
@@ -19,7 +18,10 @@ module Gimli
 
       @stylesheets = []
       parameters = [@config.wkhtmltopdf_parameters]
-      parameters << '--cover' << COVER_FILE_PATH if config.cover
+      if config.cover
+        @coverfile = Tempfile.new(['coverfile', '.html'])
+        parameters << '--cover' << @coverfile.path
+      end
       @wkhtmltopdf = Wkhtmltopdf.new parameters.join(' ')
     end
 
@@ -130,9 +132,8 @@ module Gimli
       html = "<div class=\"cover\">\n#{markup.render}\n</div>"
       append_stylesheets(html)
       html = add_head(html)
-      File.open(COVER_FILE_PATH, 'w') do |f|
-        f.write html
-      end
+      @coverfile.write(html)
+      @coverfile.close
     end
   end
 end

--- a/spec/gimli/converter_spec.rb
+++ b/spec/gimli/converter_spec.rb
@@ -131,10 +131,9 @@ describe Gimli::Converter do
       stub(renderer).render { 'fake' }
     end
 
-    FileUtils.rm_f(Gimli::Converter::COVER_FILE_PATH)
     converter.generate_cover!
-    File.exists?(Gimli::Converter::COVER_FILE_PATH).should == true
-    FileUtils.rm_f(Gimli::Converter::COVER_FILE_PATH)
+    coverfile = converter.instance_variable_get(:@coverfile)
+    File.exists?(coverfile.path).should == true
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/walle/gimli/issues/63
ref: https://github.com/walle/gimli/pull/48

I could reproduce https://github.com/walle/gimli/issues/63 by installing gimli to system ruby or changing config directory's owner to root.
As I said [here](https://github.com/walle/gimli/issues/63#issuecomment-72182216), there is no need to create temporary html file in gem's internal directory. It'll cause a permission denial if gimli is installed to system ruby.

I changed the implementation using Tempfile. Because `wkhtmltopdf` requires a cover file to have `.html` extension, I added .html extension to Tempfile.