### PR TITLE
add support for a simple json ordering file

### DIFF
--- a/lib/gimli.rb
+++ b/lib/gimli.rb
@@ -8,9 +8,20 @@ require 'gimli/converter'
 require 'gimli/path'
 require 'gimli/wkhtmltopdf'
 
+require 'json'
+
 require File.expand_path(File.dirname(__FILE__)) + '/../ext/github_markup.rb'
 
 module Gimli
+
+  # look for an ordering file to use.  Probably a little nicer for the name of this file
+  # to be on a config flag.
+  if (File.exists?('order.json'))
+    puts "Ordering file found"
+    @ordering = JSON.parse(File.read('order.json'))
+  else
+    @ordering = nil
+  end
 
   # Create a config object
   # @example Example usage
@@ -25,9 +36,25 @@ module Gimli
     config
   end
 
+  # find the ordering index for the given filename (without extension). If the ordering file
+  # was nil then we just return 0 for every file. Otherwise we lookup the file name, returning -1
+  # if it does not have an index in the order array.
+  def self.find_index(name)
+    if (@ordering == nil)
+     0
+    else
+     @ordering.find_index(name) || -1
+    end
+  end
+
   # Starts the processing of selected files
   def self.process!(config)
     @files = Path.list_valid(config.file, config.recursive).map { |file| MarkupFile.new(file) }
+    @files.sort! { |left, right| self.find_index(left.name) <=> self.find_index(right.name) }
+    # here we filter out files that did not have an entry in the ordering array. this could possibly
+    # go on a config flag.
+    @files.select! { |v| self.find_index(v.name) != -1 }
     Converter.new(@files, config).convert!
   end
 end
+


### PR DESCRIPTION
Hi

I'm opening this as a PR primarily because it makes it easy to look at the individual changes, but I know that what I've currently got is a little rough around the edges and likely would need polishing if you wanted to merge.

I had a directory of `.md` files - the jsPlumb docs - from which I wanted to create a PDF. This tool made that very easy, but I couldn't see a way to control the ordering of the files (other than perhaps renaming them all) in the output PDF. So I added support for a JSON file consisting of a single array of file names (without extension):

```
[
  "foo",
  "bar",
  "baz"
]
```

It's expected to be called (hardcoded right now) `order.json`, and to be found in the current directory.  Also another piece of behaviour that is hardcoded is that if a particular file is not listed in the ordering file, it is excluded from the PDF output. 

Anyway - just wanted to float this idea past you.  If you want to pursue it let me know and we can chat about what needs to happen to tighten it up.
