### PR TITLE
Fix Overlapping text when repeating headers/footers in table

### DIFF
--- a/config/style.css
+++ b/config/style.css
@@ -153,6 +153,9 @@ table {
   width: 100%;
   overflow: auto;
   display: block;
+  clear: both;
+  border-collapse: collapse;
+  table-layout: auto;
 }
 
 table th {
@@ -165,6 +168,7 @@ table th, table td {
 }
 
 table tr {
+  page-break-inside: avoid;
   border-top: 1px solid #ccc;
   background-color: #fff;
 }


### PR DESCRIPTION
Fixes wkhtmltopdf issue https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1524 with a CSS adjustment suggested by @jmas