### PR TITLE
Fix wkhtmltopdf version…

### DIFF
--- a/gimli.gemspec
+++ b/gimli.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'RedCloth', '~> 4.2.7'
 
   s.add_dependency 'coderay', '~> 1.1'
-  s.add_dependency 'nokogiri', '~> 1.6.3'
+  s.add_dependency 'nokogiri', '~> 1.8.0'
 
-  s.add_dependency 'wkhtmltopdf-binary', '~> 0.9.9.3'
+  s.add_dependency 'wkhtmltopdf-binary', '~> 0.12.3'
   s.add_dependency 'optiflag', '~> 0.7'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
…because for some reason 0.9.9 was not outputing anything anymore.

On a fresh Ruby install, just running `gem install gimli` provides a version that just does not output anything 😢 

To be honest, I haven't really dug into the root cause, because just bumping `wkhtmltopdf-binary` to the latest version fixes the problem. And I also included a bump of `nokogiri` to remove those `warning: constant ::Fixnum is deprecated` messages 🔧 