### PR TITLE
Optimize the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-FROM nepalez/ruby:latest
+FROM ruby:2.4-slim
 
 MAINTAINER Fredrik Wallgren <fredrik.wallgren@gmail.com>
 
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y libfontconfig1 libxtst6 build-essential xorg libssl-dev libxrender-dev
+ENV DEBIAN_FRONTEND noninteractive
+RUN buildDependencies=' \
+      build-essential \
+    ' \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends --no-install-suggests ${buildDependencies} \
+ && gem install gimli \
+ && apt-get purge -y --auto-remove ${buildDependencies} \
+ && rm -rf /var/lib/apt/lists/*
 
-# Install gimli
-RUN gem install gimli
+# Make this image a wrapper for the CLI
+ENTRYPOINT ["gimli"]
 
-ENTRYPOINT ["/usr/local/bin/gimli"]
-
-# Show the extended help
+# Show the extended help by default
 CMD ["-h"]


### PR DESCRIPTION
This is done by:
* using an official and slim base image
* reducing the number of steps/layers
* properly cleaning up the build dependencies

Here is a comparison on the final images size:
```
→ docker image ls | sed '1p;/gimli/!d'
REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
walle/gimli               latest              99a9a52b4391        7 weeks ago         1.01GB
walle/gimli               optimized           a3cfe63c4571        2 hours ago         320MB
```

I used the `optimized` tag locally, but it should probably become either `slim` or even the default (`latest`), imho.