### PR TITLE
Add an Alpine-based Docker image

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,13 @@
+FROM ruby:2.4-alpine
+
+MAINTAINER Fredrik Wallgren <fredrik.wallgren@gmail.com>
+
+RUN apk --update add --no-cache --virtual .gimli-build-dependencies \
+      build-base \
+ && gem install gimli \
+ && apk del .gimli-build-dependencies
+
+ENTRYPOINT ["gimli"]
+
+# Show the extended help
+CMD ["-h"]


### PR DESCRIPTION
Yep, that's it, a Docker image, based on Alpine.

Here is the comparison of the final images size:
```
→ docker image ls | sed '1p;/gimli/!d'
REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
walle/gimli               latest              99a9a52b4391        7 weeks ago         1.01GB
walle/gimli               alpine              0b65875e55db        5 hours ago         152MB
```

Huge size improvement, perfect for simple CLI distribution 🚀 